### PR TITLE
Ensure teacher navigation replays from the correct starting FEN

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,9 @@
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setupTests.js"
-    ]
+    ],
+    "moduleNameMapper": {
+      "\\.(css|less|scss)$": "<rootDir>/tests/styleMock.js"
+    }
   }
 }

--- a/frontend/src/lib/socket.js
+++ b/frontend/src/lib/socket.js
@@ -59,9 +59,11 @@ export function retractVote(gameId, move, userId) {
   socket.emit('retract_vote', { gameId, move, userId });
 }
 
-export function updateBoard(gameId, fen, moveHistory) {
-  console.log('[socket.js] updateBoard called:', { gameId, fen, moveHistory });
-  socket.emit('update_board', { gameId, fen, moveHistory });
+export function updateBoard(gameId, fen, moveHistory, initialFen) {
+  const payload = { gameId, fen, moveHistory };
+  if (initialFen) payload.initialFen = initialFen;
+  console.log('[socket.js] updateBoard called:', payload);
+  socket.emit('update_board', payload);
   console.log('[socket.js] update_board emitted');
 }
 

--- a/frontend/tests/styleMock.js
+++ b/frontend/tests/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/tests/views/TeacherView.test.jsx
+++ b/frontend/tests/views/TeacherView.test.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { Chess } from 'chess.js';
+import TeacherView from '../../src/views/TeacherView';
+
+jest.mock('../../src/lib/socket', () => {
+  const listeners = {};
+
+  function addListener(event, handler) {
+    if (!listeners[event]) listeners[event] = new Set();
+    listeners[event].add(handler);
+  }
+
+  function removeListener(event, handler) {
+    if (!listeners[event]) return;
+    if (handler) {
+      listeners[event].delete(handler);
+    } else {
+      listeners[event].clear();
+    }
+    if (listeners[event] && listeners[event].size === 0) {
+      delete listeners[event];
+    }
+  }
+
+  const socketMock = {
+    emit: jest.fn(),
+    on: jest.fn((event, handler) => addListener(event, handler)),
+    off: jest.fn((event, handler) => removeListener(event, handler)),
+  };
+
+  return {
+    joinGame: jest.fn(),
+    updateBoard: jest.fn(),
+    setMode: jest.fn(),
+    socket: socketMock,
+    __emitSocketEvent: (event, payload) => {
+      if (!listeners[event]) return;
+      for (const handler of Array.from(listeners[event])) {
+        handler(payload);
+      }
+    },
+    __resetSocketListeners: () => {
+      Object.keys(listeners).forEach(key => delete listeners[key]);
+    }
+  };
+});
+
+import { socket, updateBoard, __emitSocketEvent, __resetSocketListeners } from '../../src/lib/socket';
+
+describe('TeacherView move navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetSocketListeners();
+    window.socket = socket;
+  });
+
+  afterEach(() => {
+    delete window.socket;
+  });
+
+  it('replays moves using the initial FEN when jumping within history', async () => {
+    const startFen = '8/8/8/8/8/3K4/8/3k4 w - - 0 1';
+    const chess = new Chess(startFen);
+    const firstSan = chess.move('Kd4').san;
+    const afterFirstFen = chess.fen();
+    const secondSan = chess.move('Kd2').san;
+    const finalFen = chess.fen();
+    const history = [firstSan, secondSan];
+
+    render(<TeacherView />);
+
+    act(() => {
+      __emitSocketEvent('board_update', {
+        fen: finalFen,
+        moveHistory: history,
+        initialFen: startFen
+      });
+    });
+
+    updateBoard.mockClear();
+
+    const firstMoveCell = await screen.findByText(firstSan);
+    act(() => {
+      fireEvent.click(firstMoveCell);
+    });
+
+    await waitFor(() => {
+      expect(updateBoard).toHaveBeenCalledWith('default-game', afterFirstFen, history, startFen);
+    });
+
+    updateBoard.mockClear();
+
+    const backButton = screen.getByRole('button', { name: /</ });
+    act(() => {
+      fireEvent.click(backButton);
+    });
+
+    await waitFor(() => {
+      expect(updateBoard).toHaveBeenCalledWith('default-game', startFen, history, startFen);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- track each game's starting FEN in the backend and include it with board_update events
- rebuild teacher move history positions from the recorded initial FEN and send it on every update_board emit
- add focused Jest tests for teacher navigation and refresh StudentView coverage while stubbing CSS modules for Jest

## Testing
- npx --yes jest


------
https://chatgpt.com/codex/tasks/task_e_68cf4896bc7c8329a545f0e473da086a